### PR TITLE
Add ROS 2 foxglove bridge to docker image

### DIFF
--- a/docker/docker_run.sh
+++ b/docker/docker_run.sh
@@ -8,6 +8,7 @@ docker run -it \
     -e NVIDIA_DRIVER_CAPABILITIES=all \
     --device /dev/dri:/dev/dri \
     -e DISPLAY=$DISPLAY \
+    -p 8765:8765 \
     -v ${SCRIPTPATH}/../px4_roscon_25:/home/ubuntu/roscon-25-workshop_ws/src/ \
     --name=px4-roscon-25 \
     dronecode/roscon-25-workshop bash

--- a/docker/docker_run_nogui.sh
+++ b/docker/docker_run_nogui.sh
@@ -6,4 +6,5 @@ docker run -it \
     -v ${SCRIPTPATH}/../px4_roscon_25:/home/ubuntu/roscon-25-workshop_ws/src/ \
     --name=px4-roscon-25 \
     -p 18570:18570/udp \
+    -p 8765:8765 \
     dronecode/roscon-25-workshop bash

--- a/docker/docker_run_wsl.sh
+++ b/docker/docker_run_wsl.sh
@@ -7,6 +7,7 @@ docker run -it \
     -e DISPLAY=$DISPLAY \
     -e NVIDIA_VISIBLE_DEVICES=all \
     -e NVIDIA_DRIVER_CAPABILITIES=all \
+    -p 8765:8765 \
     -v ${SCRIPTPATH}/../px4_roscon_25:/home/ubuntu/roscon-25-workshop_ws/src/ \
     --name=px4-roscon-25 \
     --runtime nvidia \

--- a/docker/scripts/install_deps.sh
+++ b/docker/scripts/install_deps.sh
@@ -12,6 +12,7 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-
 apt-get update && \
 apt-get install -y --no-install-recommends \
     gz-harmonic \
+    ros-humble-foxglove-bridge \
     bc \
     dmidecode \
     libboost-all-dev \


### PR DESCRIPTION
Adds `ros-humble-foxglove-bridge` to the base image and configures the docker run command to expose foxglove `8765` default port