### PR TITLE
Fix architecture check for QGC installation script

### DIFF
--- a/docker/scripts/install_qgc.sh
+++ b/docker/scripts/install_qgc.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 
 QGC_VERSION=$1
 
-if ["${TARGETARCH}" = "amd64" ]; then
+if [ "$(uname -m)" = "x86_64" ]; then
     cd /home/${USER}
     wget https://github.com/mavlink/qgroundcontrol/releases/download/${QGC_VERSION}/QGroundControl-x86_64.AppImage
     chmod +x ./QGroundControl-x86_64.AppImage


### PR DESCRIPTION
The QGC installation did a false fail on my PC.
With the proposed changes QGC installs properly.
Not sure if it works on all architectures.

patrik_ark@patrik-ark:~/ARK/Dev/ROSCon/roscon-25-workshop$ ./docker/docker_run.sh ubuntu@d26da91c5859:~$ cd QGroundControl/ ubuntu@d26da91c5859:~/QGroundControl$ ls install.log ubuntu@d26da91c5859:~/QGroundControl$ cat install.log QGroundControl is only available for amd64 architecture.
